### PR TITLE
PoC2: CLIをリファクタリング

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,3 +175,7 @@ cython_debug/
 
 # autoscripts-csv
 output.csv
+output.txt
+
+# PoC2
+**/generate_sample_pdf.py

--- a/poetry.lock
+++ b/poetry.lock
@@ -565,6 +565,24 @@ pytest = ">=4.6"
 testing = ["fields", "hunter", "process-tests", "pytest-xdist", "virtualenv"]
 
 [[package]]
+name = "pytest-mock"
+version = "3.14.0"
+description = "Thin-wrapper around the mock package for easier use with pytest"
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "pytest-mock-3.14.0.tar.gz", hash = "sha256:2719255a1efeceadbc056d6bf3df3d1c5015530fb40cf347c0f9afac88410bd0"},
+    {file = "pytest_mock-3.14.0-py3-none-any.whl", hash = "sha256:0b72c38033392a5f4621342fe11e9219ac11ec9d375f8e2a0c164539e0d70f6f"},
+]
+
+[package.dependencies]
+pytest = ">=6.2.5"
+
+[package.extras]
+dev = ["pre-commit", "pytest-asyncio", "tox"]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 description = "Extensions to the standard Python datetime module"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,8 @@ pytest = "^8.3.5"
 pytest-cov = "^6.1.1"
 pre-commit = "^4.2.0"
 ruff = "^0.11.8"
+pymupdf = "^1.25.5"
+pytest-mock = "^3.14.0"
 
 [tool.poetry.scripts]
 autoscripts-csv = "autoscripts_csv.cli:main"

--- a/src/autoscripts_csv/poc/micro02_pdf/cli.py
+++ b/src/autoscripts_csv/poc/micro02_pdf/cli.py
@@ -1,0 +1,60 @@
+import argparse
+import sys
+from pathlib import Path
+
+from autoscripts_csv.poc.common.notify import post_to_slack
+from autoscripts_csv.poc.micro02_pdf.extractor import extract_text_from_pdf
+
+
+class CLIError(Exception):
+    """CLIエラーを表すカスタム例外"""
+
+    pass
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="autoscripts-csv", description="PDFファイルからテキストを抽出するCLI"
+    )
+    parser.add_argument(
+        "--pdf", type=Path, required=True, help="文字列を抽出したいPDFのパス"
+    )
+    parser.add_argument("--output", type=Path, required=False, help="出力ファイル名")
+    parser.add_argument(
+        "--notify", action="store_true", help="Slackに通知を送るかどうか"
+    )
+    return parser
+
+
+def run(args: argparse.Namespace) -> None:
+    if not args.pdf.exists():
+        raise CLIError(f"PDFファイルが見つかりません: {args.pdf}")
+
+    data = extract_text_from_pdf(args.pdf)
+
+    if args.notify:
+        post_to_slack(data)
+
+    if args.output:
+        args.output.write_text(data, encoding="utf-8")
+    else:
+        print("抽出内容は以下です")
+        print(data)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    try:
+        args = parser.parse_args(argv)
+        run(args)
+        return 0
+    except CLIError as e:
+        print(f"[ERROR] {e}", file=sys.stderr)
+        return 1
+    except Exception as e:
+        print(f"[UNEXPECTED ERROR] {e}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/autoscripts_csv/poc/micro02_pdf/tests/test_micro02_cli.py
+++ b/src/autoscripts_csv/poc/micro02_pdf/tests/test_micro02_cli.py
@@ -1,0 +1,67 @@
+from pathlib import Path
+
+import pytest
+
+from autoscripts_csv.poc.micro02_pdf.cli import main
+
+
+def test_cli_output(tmp_path, capsys):
+    sample_pdf = Path(__file__).parent / "fixtures" / "sample.pdf"
+    out_file = tmp_path / "result.txt"
+
+    exit_code = main(["--pdf", str(sample_pdf), "--output", str(out_file)])
+    assert exit_code == 0
+
+    assert out_file.exists()
+    text = out_file.read_text(encoding="utf-8")
+    assert "Invoice" in text
+    assert "Total amount" in text
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+
+
+def test_missing_pdf_file(tmp_path, capsys):
+    fake_pdf = tmp_path / "notfound.pdf"
+    out_file = tmp_path / "result.txt"
+
+    exit_code = main(["--pdf", str(fake_pdf), "--output", str(out_file)])
+
+    assert exit_code == 1
+    captured = capsys.readouterr()
+    assert "PDFファイルが見つかりません" in captured.err
+
+
+def test_missing_pdf_arg(capsys):
+    with pytest.raises(SystemExit) as exc:
+        main([])
+
+    assert exc.value.code == 2
+    captured = capsys.readouterr()
+    assert "usage:" in captured.err
+
+
+def test_output_write_error(tmp_path, capsys):
+    sample_pdf = Path(__file__).parent / "fixtures" / "sample.pdf"
+    error_dir = tmp_path / "no_such_dir"
+    out_file = error_dir / "output.txt"
+
+    exit_code = main(["--pdf", str(sample_pdf), "--output", str(out_file)])
+
+    # 書き込み失敗 → exit 2（想定外の例外）
+    assert exit_code == 2
+
+    captured = capsys.readouterr()
+    assert "UNEXPECTED ERROR" in captured.err
+
+
+def test_notify_called(tmp_path, mocker):
+    mock = mocker.patch("autoscripts_csv.poc.micro02_pdf.cli.post_to_slack")
+
+    sample_pdf = Path(__file__).parent / "fixtures" / "sample.pdf"
+    out_file = tmp_path / "result.txt"
+
+    exit_code = main(["--pdf", str(sample_pdf), "--output", str(out_file), "--notify"])
+    assert exit_code == 0
+
+    mock.assert_called_once()


### PR DESCRIPTION
## 概要

PoC2を整備。  
PoC1に比べて構造を明確にし、テスト可能な形にリファクタリング。

---

## 仕様

- PDFファイルのパスを受け取り、文字列を抽出
- `--output` オプション指定時はファイルに保存
- `--notify` 指定時はSlack通知（PoC1と共通の `common/notify.py` を再利用）
- CLI構造を `main(argv)`, `build_parser()`, `run(args)` に分離して再利用性・テスト容易性を向上

---

## テスト

- `pytest` による正常系／異常系を確認

---

## 実行例

```bash
poetry run python cli.py --pdf tests/fixtures/sample.pdf --notify
poetry run python cli.py --pdf tests/fixtures/sample.pdf --output result.txt